### PR TITLE
update SortedSet_Comparable.mop to avoid false alarm

### DIFF
--- a/annotated-java-api/java/util/SortedSet_Comparable.mop
+++ b/annotated-java-api/java/util/SortedSet_Comparable.mop
@@ -27,23 +27,24 @@ import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
  * @severity error
  */
 
-SortedSet_Comparable() {
-	event add before(Object e) :
+SortedSet_Comparable(SortedSet s) {
+
+	event add before(SortedSet s, Object e) :
 		(
 			call(* Collection+.add*(..)) ||
 			call(* Queue+.offer*(..))
-		) && target(SortedSet) && args(e) {
-		if (!(e instanceof Comparable)) {
+		) && target(s) && args(e) {
+		if (s.comparator() == null && !(e instanceof Comparable)) {
 			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
 			RVMLogging.out.println(Level.CRITICAL, "A non-comparable object is being inserted into a SortedSet object.");
 		}
 	}
 
-	event addall before(Collection c) :
+	event addall before(SortedSet s, Collection c) :
 		call(* Collection+.addAll(Collection)) &&
-		target(SortedSet) && args(c) {
+		target(s) && args(c) {
 		for (Object elem : c) {
-			if (!(elem instanceof Comparable)) {
+			if (s.comparator() == null && !(elem instanceof Comparable)) {
 				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
 				RVMLogging.out.println(Level.CRITICAL, "A non-comparable object is being inserted into a SortedSet object.");
 			}


### PR DESCRIPTION
The test case that I used is quite a simple one:

```
import java.util.*;

public class Test 
{
    public static void main(String[] args) 
    {
Comparator<JzonElement> COMP = 
    new Comparator<JzonElement>() {
@Override
    public int compare(JzonElement o1,
            JzonElement o2) {return o1.val - o2.val;}
};

        Set<JzonElement> memb = 
            new TreeSet <JzonElement> (COMP);
//  new TreeSet <JzonElement> (); //switch these two constructors to compare

memb.add(new JzonElement(22));

Collection<JzonElement> aList = new ArrayList<JzonElement>();
aList.add(new JzonElement(5));
aList.add(new JzonElement(7));

memb.addAll(aList);

    }
}

class JzonElement
{
    public int val;

    public JzonElement(int val) {this.val = val;}
}

```
