### PR TITLE
fix bug in Math_ContendedRandom.mop

### DIFF
--- a/annotated-java-api/java/lang/Math_ContendedRandom.mop
+++ b/annotated-java-api/java/lang/Math_ContendedRandom.mop
@@ -24,7 +24,7 @@ Math_ContendedRandom() {
 			this.th = t;
 		}
 	event otherthread_use before(Thread t) :
-		call(* Math.random(..)) && thread(t) && condition(this.th != t){
+		call(* Math.random(..)) && thread(t) && condition(this.th != null && this.th != t){
 		}
 
 	ere : onethread_use*


### PR DESCRIPTION
This PR fixes `Math_ContendedRandom.mop` so that it is not violated on every invocation of `Math.random()`, even in single-threaded programs.

@yzhang90 please review